### PR TITLE
fix stop service statsd ubuntu/debian

### DIFF
--- a/files/statsd-init
+++ b/files/statsd-init
@@ -59,7 +59,7 @@ stop() {
   #   1 if daemon was already stopped
   #   2 if daemon could not be stopped
   #   other if a failure occurred
-  start-stop-daemon --stop --quiet --retry=TERM/30/KILL/5 --pidfile $PIDFILE --name statsd
+  start-stop-daemon --stop --quiet --retry=TERM/30/KILL/5 --pidfile $PIDFILE
   RETVAL=$?
   # Many daemons don't delete their pidfiles when they exit.
   log_end_msg $RETVAL


### PR DESCRIPTION
--name don't needed to stop statsd
